### PR TITLE
Update README.md replacing npx es4x-pm init -> npx es4x init

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create a project:
 # create a generic project
 mkdir my-app
 cd my-app
-npx es4x-pm init
+npx es4x init
 # add dependencies
 npm install @vertx/unit --save-dev
 npm install @vertx/core --save-prod


### PR DESCRIPTION
I tried to use

> npx es4x-pm init

it provides an error message warning that: npx: command not found: es4x-pm
and we replace es4x-pm with es4x then run

> npx es4x init

it works