### PR TITLE
WiP for thenable futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&type=jdk&release=latest&heap_size=normal&arch=x64"
   # GraalVM
     - env: JDK='GraalVM 19'
-      install: . ./install-jdk.sh --url "https://github.com/oracle/graal/releases/download/vm-19.0.2/graalvm-ce-linux-amd64-19.0.2.tar.gz"
+      install: . ./install-jdk.sh --url "https://github.com/oracle/graal/releases/download/vm-19.1.0/graalvm-ce-linux-amd64-19.1.0.tar.gz"
   # OpenJ9
     - env: JDK='OpenJ9'
       install: . ./install-jdk.sh --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&type=jdk&release=latest&heap_size=normal&arch=x64"

--- a/es4x/src/main/java/io/reactiverse/es4x/JSVerticleFactory.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/JSVerticleFactory.java
@@ -15,10 +15,7 @@
  */
 package io.reactiverse.es4x;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 
 public final class JSVerticleFactory extends ESVerticleFactory {
 
@@ -46,7 +43,7 @@ public final class JSVerticleFactory extends ESVerticleFactory {
       }
 
       @Override
-      public void start(Future<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startFuture) throws Exception {
         final String address;
         final boolean worker;
         final Object self;
@@ -105,7 +102,7 @@ public final class JSVerticleFactory extends ESVerticleFactory {
       }
 
       @Override
-      public void stop(Future<Void> stopFuture) {
+      public void stop(Promise<Void> stopFuture) {
         try {
           runtime.enter();
           runtime.emit("undeploy");

--- a/es4x/src/main/java/io/reactiverse/es4x/MJSVerticleFactory.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/MJSVerticleFactory.java
@@ -16,10 +16,7 @@
 package io.reactiverse.es4x;
 
 import io.reactiverse.es4x.impl.ESModuleIO;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import org.graalvm.polyglot.io.FileSystem;
 
@@ -50,7 +47,7 @@ public final class MJSVerticleFactory extends ESVerticleFactory {
       }
 
       @Override
-      public void start(Future<Void> startFuture) throws Exception {
+      public void start(Promise<Void> startFuture) throws Exception {
         final FileSystem fs = engine.fileSystem();
 
         try {
@@ -73,7 +70,7 @@ public final class MJSVerticleFactory extends ESVerticleFactory {
       }
 
       @Override
-      public void stop(Future<Void> stopFuture) {
+      public void stop(Promise<Void> stopFuture) {
         try {
           runtime.enter();
           runtime.emit("undeploy");

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFailedFuture.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFailedFuture.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.reactiverse.es4x.impl.future;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.NoStackTraceThrowable;
+import org.graalvm.polyglot.Value;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ES4XFailedFuture<T> implements Future<T>, Promise<T>, Thenable {
+
+  private final Throwable cause;
+
+  /**
+   * Create a future that has already failed
+   * @param t the throwable
+   */
+  ES4XFailedFuture(Throwable t) {
+    cause = t != null ? t : new NoStackTraceThrowable(null);
+  }
+
+  /**
+   * Create a future that has already failed
+   * @param failureMessage the failure message
+   */
+  ES4XFailedFuture(String failureMessage) {
+    this(new NoStackTraceThrowable(failureMessage));
+  }
+
+  @Override
+  public boolean isComplete() {
+    return true;
+  }
+
+  @Override
+  public Future<T> setHandler(Handler<AsyncResult<T>> handler) {
+    handler.handle(this);
+    return this;
+  }
+
+  @Override
+  public Value then(Value... arguments) {
+    final Value reject = Thenable.getFunction(arguments, 1);
+
+    if (reject != null) {
+      reject.execute(cause());
+    }
+
+    return null;
+  }
+
+  @Override
+  public Handler<AsyncResult<T>> getHandler() {
+    return null;
+  }
+
+  @Override
+  public void complete(T result) {
+    throw new IllegalStateException("Result is already complete: failed");
+  }
+
+  @Override
+  public void complete() {
+    throw new IllegalStateException("Result is already complete: failed");
+  }
+
+  @Override
+  public void fail(Throwable cause) {
+    throw new IllegalStateException("Result is already complete: failed");
+  }
+
+  @Override
+  public void fail(String failureMessage) {
+    throw new IllegalStateException("Result is already complete: failed");
+  }
+
+  @Override
+  public boolean tryComplete(T result) {
+    return false;
+  }
+
+  @Override
+  public boolean tryComplete() {
+    return false;
+  }
+
+  @Override
+  public boolean tryFail(Throwable cause) {
+    return false;
+  }
+
+  @Override
+  public boolean tryFail(String failureMessage) {
+    return false;
+  }
+
+  @Override
+  public T result() {
+    return null;
+  }
+
+  @Override
+  public Throwable cause() {
+    return cause;
+  }
+
+  @Override
+  public boolean succeeded() {
+    return false;
+  }
+
+  @Override
+  public boolean failed() {
+    return true;
+  }
+
+  @Override
+  public void handle(AsyncResult<T> asyncResult) {
+    throw new IllegalStateException("Result is already complete: failed");
+  }
+
+  @Override
+  public Future<T> future() {
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "Future{cause=" + cause.getMessage() + "}";
+  }
+}

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFuture.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFuture.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.reactiverse.es4x.impl.future;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import org.graalvm.polyglot.Value;
+
+class ES4XFuture<T> implements Promise<T>, Future<T>, Thenable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ES4XFuture.class);
+
+  private boolean failed;
+  private boolean succeeded;
+  private Handler<AsyncResult<T>> handler;
+  private T result;
+  private Throwable throwable;
+
+  /**
+   * Create a future that hasn't completed yet
+   */
+  ES4XFuture() {
+  }
+
+  /**
+   * The result of the operation. This will be null if the operation failed.
+   */
+  public synchronized T result() {
+    return result;
+  }
+
+  /**
+   * An exception describing failure. This will be null if the operation succeeded.
+   */
+  public synchronized Throwable cause() {
+    return throwable;
+  }
+
+  /**
+   * Did it succeeed?
+   */
+  public synchronized boolean succeeded() {
+    return succeeded;
+  }
+
+  /**
+   * Did it fail?
+   */
+  public synchronized boolean failed() {
+    return failed;
+  }
+
+  /**
+   * Has it completed?
+   */
+  public synchronized boolean isComplete() {
+    return failed || succeeded;
+  }
+
+  /**
+   * Set a handler for the result. It will get called when it's complete
+   */
+  public Future<T> setHandler(Handler<AsyncResult<T>> handler) {
+    boolean callHandler;
+    synchronized (this) {
+      callHandler = isComplete();
+      if (!callHandler) {
+        this.handler = handler;
+      }
+    }
+    if (callHandler) {
+      handler.handle(this);
+    }
+    return this;
+  }
+
+  @Override
+  public Value then(Value... arguments) {
+    // Both onFulfilled and onRejected are optional arguments
+    final Value onFulfilled = Thenable.getFunction(arguments, 0);
+    final Value onRejected = Thenable.getFunction(arguments, 1);
+
+    setHandler(ar -> {
+      if (ar.succeeded()) {
+        try {
+          if (onFulfilled != null) {
+            onFulfilled.executeVoid(ar.result());
+          }
+        } catch (RuntimeException e) {
+          // resolve failed, attempt to reject
+          if (onRejected != null) {
+            onRejected.execute(e);
+          } else {
+            LOG.warn("Possible Unhandled Promise Rejection: " + e.getMessage());
+          }
+        }
+      } else {
+        if (onRejected != null) {
+          onRejected.execute(ar.cause());
+        }
+      }
+    });
+
+    return null;
+  }
+
+  @Override
+  public synchronized Handler<AsyncResult<T>> getHandler() {
+    return handler;
+  }
+
+  @Override
+  public void complete(T result) {
+    if (!tryComplete(result)) {
+      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
+    }
+  }
+
+  @Override
+  public void complete() {
+    if (!tryComplete()) {
+      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
+    }
+  }
+
+  @Override
+  public void fail(Throwable cause) {
+    if (!tryFail(cause)) {
+      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
+    }
+  }
+
+  @Override
+  public void fail(String failureMessage) {
+    if (!tryFail(failureMessage)) {
+      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
+    }
+  }
+
+  @Override
+  public boolean tryComplete(T result) {
+    Handler<AsyncResult<T>> h;
+    synchronized (this) {
+      if (succeeded || failed) {
+        return false;
+      }
+      this.result = result;
+      succeeded = true;
+      h = handler;
+      handler = null;
+    }
+    if (h != null) {
+      h.handle(this);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean tryComplete() {
+    return tryComplete(null);
+  }
+
+  public void handle(Future<T> ar) {
+    if (ar.succeeded()) {
+      complete(ar.result());
+    } else {
+      fail(ar.cause());
+    }
+  }
+
+  @Override
+  public void handle(AsyncResult<T> asyncResult) {
+    if (asyncResult.succeeded()) {
+      complete(asyncResult.result());
+    } else {
+      fail(asyncResult.cause());
+    }
+  }
+
+  @Override
+  public boolean tryFail(Throwable cause) {
+    Handler<AsyncResult<T>> h;
+    synchronized (this) {
+      if (succeeded || failed) {
+        return false;
+      }
+      this.throwable = cause != null ? cause : new NoStackTraceThrowable(null);
+      failed = true;
+      h = handler;
+      handler = null;
+    }
+    if (h != null) {
+      h.handle(this);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean tryFail(String failureMessage) {
+    return tryFail(new NoStackTraceThrowable(failureMessage));
+  }
+
+  @Override
+  public Future<T> future() {
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    synchronized (this) {
+      if (succeeded) {
+        return "Future{result=" + result + "}";
+      }
+      if (failed) {
+        return "Future{cause=" + throwable.getMessage() + "}";
+      }
+      return "Future{unresolved}";
+    }
+  }
+}

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFutureFactory.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XFutureFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.reactiverse.es4x.impl.future;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.spi.FutureFactory;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class ES4XFutureFactory implements FutureFactory {
+
+  private static final ES4XSucceededFuture EMPTY = new ES4XSucceededFuture<>(null);
+
+  @Override
+  public <T> Promise<T> promise() {
+    return new ES4XFuture<>();
+  }
+
+  @Override
+  public <T> Promise<T> succeededPromise() {
+    @SuppressWarnings("unchecked")
+    Promise<T> promise = EMPTY;
+    return promise;
+  }
+
+  @Override
+  public <T> Promise<T> succeededPromise(T result) {
+    return new ES4XSucceededFuture<>(result);
+  }
+
+  @Override
+  public <T> Promise<T> failedPromise(Throwable t) {
+    return new ES4XFailedFuture<>(t);
+  }
+
+  @Override
+  public <T> Promise<T> failurePromise(String failureMessage) {
+    return new ES4XFailedFuture<>(failureMessage);
+  }
+
+  @Override
+  public <T> Future<T> future() {
+    return new ES4XFuture<>();
+  }
+
+  @Override
+  public <T> Future<T> succeededFuture() {
+    @SuppressWarnings("unchecked")
+    Future<T> fut = EMPTY;
+    return fut;
+  }
+
+  @Override
+  public <T> Future<T> succeededFuture(T result) {
+    return new ES4XSucceededFuture<>(result);
+  }
+
+  @Override
+  public <T> Future<T> failedFuture(Throwable t) {
+    return new ES4XFailedFuture<>(t);
+  }
+
+  @Override
+  public <T> Future<T> failureFuture(String failureMessage) {
+    return new ES4XFailedFuture<>(failureMessage);
+  }
+}

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XSucceededFuture.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/future/ES4XSucceededFuture.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.reactiverse.es4x.impl.future;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import org.graalvm.polyglot.Value;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class ES4XSucceededFuture<T> implements Future<T>, Promise<T>, Thenable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ES4XSucceededFuture.class);
+
+  private final T result;
+
+  /**
+   * Create a future that has already succeeded
+   * @param result the result
+   */
+  ES4XSucceededFuture(T result) {
+    this.result = result;
+  }
+
+  @Override
+  public boolean isComplete() {
+    return true;
+  }
+
+  @Override
+  public Future<T> setHandler(Handler<AsyncResult<T>> handler) {
+    handler.handle(this);
+    return this;
+  }
+
+  @Override
+  public Value then(Value... arguments) {
+    final Value resolve = Thenable.getFunction(arguments, 0);
+    final Value reject = Thenable.getFunction(arguments, 1);
+
+    try {
+      if (resolve != null) {
+        resolve.executeVoid(result());
+      }
+    } catch (RuntimeException e) {
+      // resolve failed, attempt to reject
+      if (reject != null) {
+        reject.execute(e);
+      } else {
+        LOG.warn("Possible Unhandled Promise Rejection: " + e.getMessage());
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public Handler<AsyncResult<T>> getHandler() {
+    return null;
+  }
+
+  @Override
+  public void complete(T result) {
+    throw new IllegalStateException("Result is already complete: succeeded");
+  }
+
+  @Override
+  public void complete() {
+    throw new IllegalStateException("Result is already complete: succeeded");
+  }
+
+  @Override
+  public void fail(Throwable cause) {
+    throw new IllegalStateException("Result is already complete: succeeded");
+  }
+
+  @Override
+  public void fail(String failureMessage) {
+    throw new IllegalStateException("Result is already complete: succeeded");
+  }
+
+  @Override
+  public boolean tryComplete(T result) {
+    return false;
+  }
+
+  @Override
+  public boolean tryComplete() {
+    return false;
+  }
+
+  @Override
+  public boolean tryFail(Throwable cause) {
+    return false;
+  }
+
+  @Override
+  public boolean tryFail(String failureMessage) {
+    return false;
+  }
+
+  @Override
+  public T result() {
+    return result;
+  }
+
+  @Override
+  public Throwable cause() {
+    return null;
+  }
+
+  @Override
+  public boolean succeeded() {
+    return true;
+  }
+
+  @Override
+  public boolean failed() {
+    return false;
+  }
+
+  @Override
+  public void handle(AsyncResult<T> asyncResult) {
+    throw new IllegalStateException("Result is already complete: succeeded");
+  }
+
+  @Override
+  public Future<T> future() {
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "Future{result=" + result + "}";
+  }
+}

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/future/Thenable.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/future/Thenable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.reactiverse.es4x.impl.future;
+
+import org.graalvm.polyglot.Value;
+
+/**
+ * Thenable Object.
+ */
+@FunctionalInterface
+public interface Thenable {
+
+  Object then(Value... arguments);
+
+  static Value getFunction(Value[] arguments, int index) {
+    if (arguments != null) {
+      if (arguments.length > index) {
+        Value value = arguments[index];
+        if (value.canExecute()) {
+          return value;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/es4x/src/main/java/io/reactiverse/es4x/impl/graal/GraalEngine.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/impl/graal/GraalEngine.java
@@ -19,6 +19,7 @@ import io.reactiverse.es4x.ECMAEngine;
 import io.reactiverse.es4x.Runtime;
 import io.reactiverse.es4x.jul.ES4XFormatter;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -125,9 +126,22 @@ public class GraalEngine implements ECMAEngine {
           if (v.isNull()) {
             return null;
           }
-          final Future future = Future.future();
-          v.invokeMember("then", future);
-          return future;
+          final Promise promise = Promise.promise();
+          v.invokeMember("then", promise);
+          return promise.future();
+        })
+      // map Promise to io.vertx.core.Promise
+      .targetTypeMapping(
+        Value.class,
+        Promise.class,
+        v -> v.hasMembers() && v.hasMember("then"),
+        v -> {
+          if (v.isNull()) {
+            return null;
+          }
+          final Promise promise = Promise.promise();
+          v.invokeMember("then", promise);
+          return promise;
         })
       // Ensure Arrays are exposed as List when the Java API is accepting Object
       .targetTypeMapping(List.class, Object.class, null, v -> v)

--- a/es4x/src/main/resources/META-INF/services/io.vertx.core.spi.FutureFactory
+++ b/es4x/src/main/resources/META-INF/services/io.vertx.core.spi.FutureFactory
@@ -1,0 +1,1 @@
+io.reactiverse.es4x.impl.future.ES4XFutureFactory

--- a/es4x/src/main/resources/io/reactiverse/es4x/polyfill/promise.js
+++ b/es4x/src/main/resources/io/reactiverse/es4x/polyfill/promise.js
@@ -17,7 +17,6 @@
   'use strict';
 
   const Vertx = Java.type('io.vertx.core.Vertx');
-  const Future = Java.type('io.vertx.core.Future');
 
   function noop() {}
 
@@ -30,23 +29,8 @@
 
   function Promise(fn) {
     if (typeof this !== 'object') throw new TypeError('Promises must be constructed via new');
-    
-    if (fn && fn instanceof Future) {
-      // adapt it to a promise
-      const future = fn;
-      fn = function (resolve, reject) {
-        future.setHandler(function (ar) {
-          if (ar.succeeded()) {
-            resolve(ar.result());
-          } else {
-            reject(ar.cause());
-          }
-        })
-      }
-    } else {
-      if (typeof fn !== 'function') throw new TypeError('not a function');
-    }
-    
+    if (typeof fn !== 'function') throw new TypeError('not a function');
+
     this._state = 0;
     this._handled = false;
     this._value = undefined;
@@ -168,17 +152,6 @@
 
   Promise.prototype.then = function (onFulfilled, onRejected) {
     var prom = new Promise(noop);
-    // handle Future as Promise
-    if (onRejected === undefined && onFulfilled && onFulfilled instanceof Future) {
-      const future = onFulfilled;
-      onFulfilled = function (value) {
-        future.complete(value);
-      };
-      onRejected = function (reason) {
-        future.fail(reason);
-      };
-    }
-
     handle(this, new Handler(onFulfilled, onRejected, prom));
     return prom;
   };

--- a/es4x/src/test/java/io/reactiverse/es4x/test/FutureTest.java
+++ b/es4x/src/test/java/io/reactiverse/es4x/test/FutureTest.java
@@ -2,7 +2,6 @@ package io.reactiverse.es4x.test;
 
 import io.reactiverse.es4x.Runtime;
 import io.reactiverse.es4x.impl.graal.GraalEngine;
-import io.vertx.core.Future;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -26,36 +25,24 @@ public class FutureTest {
   }
 
   @Test(timeout = 10000)
-  public void testWrapFutureAsPromise(TestContext should) throws Exception {
+  public void testJavaThenable(TestContext should) {
     final Async test = should.async();
 
-    Future future = Future.future();
     // make it available to the script
-    runtime.put("future", future);
+    runtime.put("should", should);
     runtime.put("test", test);
     // run a small script
-    runtime.eval(
-      "new Promise(future).then((successMessage) => {\n" +
-      "  print(\"Yay! \" + successMessage);\n" +
-      "  test.complete();\n" +
-      "});");
-
-    rule.vertx().setTimer(250L, t -> future.complete("Success!"));
+    runtime.require("./future/future.js");
   }
 
   @Test(timeout = 10000)
-  public void testThenFutureAsPromise(TestContext should) throws Exception {
+  public void testCatchFutureAsPromise(TestContext should) {
     final Async test = should.async();
 
-    Future future = Future.future().setHandler(ar -> {
-      should.assertTrue(ar.succeeded());
-      should.assertEquals("yay", ar.result());
-      test.complete();
-    });
-
     // make it available to the script
-    runtime.put("future", future);
+    runtime.put("should", should);
+    runtime.put("test", test);
     // run a small script
-    runtime.eval("Promise.resolve('yay').then(future)");
+    runtime.require("./future/future2.js");
   }
 }

--- a/es4x/src/test/resources/future/future.js
+++ b/es4x/src/test/resources/future/future.js
@@ -1,13 +1,11 @@
 async function futureTest1 () {
-  let server = await {
-    then: vertx
+  let server = await vertx
       .createHttpServer()
       .requestHandler(req => {
       })
-      .listen(0)
-  };
+      .listen(0);
 
-  should.assertEquals('io.vertx.core.http.impl.HttpServerImpl', server.getClass().getName());
+  console.log('Server Ready!');
 }
 
 futureTest1()

--- a/es4x/src/test/resources/future/future.js
+++ b/es4x/src/test/resources/future/future.js
@@ -1,0 +1,19 @@
+async function futureTest1 () {
+  let server = await {
+    then: vertx
+      .createHttpServer()
+      .requestHandler(req => {
+      })
+      .listen(0)
+  };
+
+  should.assertEquals('io.vertx.core.http.impl.HttpServerImpl', server.getClass().getName());
+}
+
+futureTest1()
+  .then(function (result) {
+    test.complete();
+  })
+  .catch(function (err) {
+    print(err)
+  });

--- a/es4x/src/test/resources/future/future.js
+++ b/es4x/src/test/resources/future/future.js
@@ -15,5 +15,5 @@ futureTest1()
     test.complete();
   })
   .catch(function (err) {
-    print(err)
+    should.fail(err)
   });

--- a/es4x/src/test/resources/future/future2.js
+++ b/es4x/src/test/resources/future/future2.js
@@ -1,0 +1,19 @@
+async function futureTest2 () {
+  let server = await {
+    then: vertx
+      .createHttpServer()
+      .requestHandler(req => {
+      })
+      .listen(-1)
+  };
+
+  should.assertEquals('io.vertx.core.http.impl.HttpServerImpl', server.getClass().getName());
+}
+
+futureTest2()
+  .then(function (result) {
+    should.fail('Expected to fail with nagative port');
+  })
+  .catch(function (err) {
+    test.complete();
+  });

--- a/generator/parent/pom.xml
+++ b/generator/parent/pom.xml
@@ -132,6 +132,24 @@
               <outputDirectory>${project.build.directory}/sources/${project.artifactId}</outputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>unpack-asciidocs</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <overWriteReleases>true</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+              <includeGroupIds>${maven.groupId}</includeGroupIds>
+              <includeArtifactIds>${project.artifactId}</includeArtifactIds>
+              <includeTypes>jar</includeTypes>
+              <includeClassifiers>sources</includeClassifiers>
+              <includes>**/*.adoc</includes>
+              <excludes>override/**.*</excludes>
+              <outputDirectory>${project.build.directory}/asciidoc/${project.artifactId}</outputDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -155,12 +173,35 @@
             <configuration>
               <processors>
                 <processor>io.vertx.codegen.CodeGenProcessor</processor>
+                <processor>io.vertx.docgen.DocGenProcessor</processor>
               </processors>
               <optionMap>
                 <codegen.output>${project.basedir}</codegen.output>
+                <docgen.source>${project.build.directory}/asciidoc/${project.artifactId}</docgen.source>
+                <docgen.output>${project.basedir}/../../../docs/manual/${npm-name}</docgen.output>
               </optionMap>
               <sourceDirectory>${project.build.directory}/sources/${project.artifactId}</sourceDirectory>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>1.5.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process-asciidoc</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.build.directory}/asciidoc/${project.artifactId}</sourceDirectory>
+              <sourceDocumentName>index.adoc</sourceDocumentName>
+              <outputDirectory>${project.build.directory}/site</outputDirectory>
+              <backend>html</backend>
+              <doctype>book</doctype>
+            </configuration>
+            <phase>process-classes</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Dependency versions -->
-    <vertx.version>3.7.1</vertx.version>
+    <vertx.version>4.0.0-SNAPSHOT</vertx.version>
     <graalvm.version>19.0.2</graalvm.version>
   </properties>
 


### PR DESCRIPTION
Add `thenable` support for `vert.x` `Future` objects which means we can await on java futures as well as javascript `Promise`.

Depends on https://github.com/graalvm/graaljs/issues/186