### PR TITLE
fix: row overrides for getTemporalArray and getBigDecimalArray

### DIFF
--- a/generator/io.vertx/vertx-sql-client/Row.override.json
+++ b/generator/io.vertx/vertx-sql-client/Row.override.json
@@ -47,5 +47,7 @@
   "getPathArray": "name: string | number",
   "getPolygonArray": "name: string | number",
   "getCircleArray": "name: string | number",
-  "getIntervalArray": "name: string | number"
+  "getIntervalArray": "name: string | number",
+  "getTemporalArray": "name: string | number",
+  "getBigDecimalArray": "name: string | number"
 }


### PR DESCRIPTION
Adding `Row` overrides for `getTemporalArray` and `getBigDecimalArray` to resolve Typescript compile errors.

```
node_modules/@vertx/sql-client/index.d.ts:324:3 - error TS2416: Property 'getTemporalArray' in type 'Row' is not assignable to the same property in base type 'Tuple'.
  Type '(name: string) => any' is not assignable to type '(pos: number) => any'.
    Types of parameters 'name' and 'pos' are incompatible.
      Type 'number' is not assignable to type 'string'.

324   getTemporalArray(name: string) : any /* java.time.temporal.Temporal[] */;
      ~~~~~~~~~~~~~~~~

node_modules/@vertx/sql-client/index.d.ts:359:3 - error TS2416: Property 'getBigDecimalArray' in type 'Row' is not assignable to the same property in base type 'Tuple'.
  Type '(name: string) => any' is not assignable to type '(pos: number) => any'.
    Types of parameters 'name' and 'pos' are incompatible.
      Type 'number' is not assignable to type 'string'.

359   getBigDecimalArray(name: string) : any /* java.math.BigDecimal[] */;
      ~~~~~~~~~~~~~~~~~~
```