### PR TITLE
fixed Java method overload bug,

### DIFF
--- a/es4x/src/main/java/io/reactiverse/es4x/ECMAEngine.java
+++ b/es4x/src/main/java/io/reactiverse/es4x/ECMAEngine.java
@@ -119,7 +119,7 @@ public final class ECMAEngine {
       // Ensure bytes are supported
       .targetTypeMapping(Number.class, Byte.class, null, Number::byteValue)
       // map native JSON Object to Vert.x JSONObject
-      .targetTypeMapping(Map.class, JsonObject.class, null, JsonObject::new)
+      .targetTypeMapping(Map.class, JsonObject.class, v -> !Value.asValue(v).hasArrayElements(), JsonObject::new)
       // map native JSON Array to Vert.x JSONArray
       .targetTypeMapping(List.class, JsonArray.class, null, JsonArray::new)
       // Ensure Arrays are exposed as Set when the Java API is accepting Set


### PR DESCRIPTION
e.g. 
1. Java: 
```
method(JsonArray array); 
method(JsonObject object);
```
2. JS:
```
java.method([ "a", "b", "c" ]);// JS Native Array can convert to Java Map, { 0 : "a", 1 : "b", 2 : "c" },
java.method({ name:"vv", age:18 })
```