### PR TITLE
Fix codegen to get the right import on option extends

### DIFF
--- a/codegen/src/main/java/io/reactiverse/es4x/codegen/generator/OptionsDTS.java
+++ b/codegen/src/main/java/io/reactiverse/es4x/codegen/generator/OptionsDTS.java
@@ -121,7 +121,15 @@ public class OptionsDTS extends Generator<DataObjectModel> {
       String superScope = getNPMScope(model.getSuperType().getModule());
       if (!selfScope.equals(superScope)) {
         TypeInfo referencedType = model.getSuperType();
-        importType(writer, session, referencedType, referencedType.getSimpleName(), getNPMScope(referencedType.getRaw().getModule()));
+        String suffix = "";
+        // take care of the suffixes
+        if (referencedType.getKind() == ClassKind.ENUM) {
+          suffix = "/enums";
+        }
+        if (referencedType.getKind() == ClassKind.OTHER && referencedType.getDataObject() != null) {
+          suffix = "/options";
+        }
+        importType(writer, session, referencedType, referencedType.getSimpleName(), getNPMScope(referencedType.getRaw().getModule()) + suffix);
         imports = true;
       }
     }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

When generating options objects that extend other options we were mapping the wrong import file